### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/azezpz1/teacher_tools/security/code-scanning/1](https://github.com/azezpz1/teacher_tools/security/code-scanning/1)

To address this issue, we should add a `permissions` block that explicitly limits the permissions of the `GITHUB_TOKEN` to the minimum necessary for the workflow. Reviewing the workflow steps, none indicate that there is a need for anything more than public repository read access (e.g., actions are just checking out, installing dependencies, running formatters, and linters). Therefore, adding a root-level `permissions` block with at least `contents: read` is safest. This block should be placed at the top level of the workflow (after `name` and before `on:`) to apply to all jobs unless otherwise specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
